### PR TITLE
Handle IndexError for empty cell value in scrape

### DIFF
--- a/pylightxl/readxl.py
+++ b/pylightxl/readxl.py
@@ -7,20 +7,6 @@ from os.path import isfile
 from .database import Database
 
 
-def wrap_index_error(func):
-    def wrapped_func(*args, **kwargs):
-        try:
-            func_response = func(*args, **kwargs)
-        except IndexError:
-            func_response = None
-        return func_response
-    return wrapped_func
-
-@wrap_index_error
-def get_item_from_list(my_list, index):
-    return my_list[index]
-
-
 def readxl(fn, sheetnames=()):
     """
     Reads an xlsx or xlsm file and returns a pylightxl database
@@ -220,16 +206,6 @@ def scrape(f, sharedString):
                 except IndexError:
                     # current tag does not have a formula
                     cell_formula = ''
-
-
-                # cell_val = str(re_cell_val.findall(first_match)[0])
-                # try:
-                #     frmla = re_cell_formula.findall(first_match)
-                #     cell_formula = str(get_item_from_list(frmla, 0))
-                #     # cell_formula = str(re_cell_formula.findall(first_match)[0])
-                # except IndexError:
-                #     # current tag does not have a formula
-                #     cell_formula = ''
 
                 if is_commonString:
                     cell_val = str(sharedString[int(cell_val)])

--- a/pylightxl/readxl.py
+++ b/pylightxl/readxl.py
@@ -7,6 +7,20 @@ from os.path import isfile
 from .database import Database
 
 
+def wrap_index_error(func):
+    def wrapped_func(*args, **kwargs):
+        try:
+            func_response = func(*args, **kwargs)
+        except IndexError:
+            func_response = None
+        return func_response
+    return wrapped_func
+
+@wrap_index_error
+def get_item_from_list(my_list, index):
+    return my_list[index]
+
+
 def readxl(fn, sheetnames=()):
     """
     Reads an xlsx or xlsm file and returns a pylightxl database
@@ -195,12 +209,27 @@ def scrape(f, sharedString):
                 is_commonString = True if 't="s"' in first_match else False
                 is_string = True if 't="str"' in first_match else False
 
-                cell_val = str(re_cell_val.findall(first_match)[0])
+                try:
+                    cell_val = str(re_cell_val.findall(first_match)[0])
+                except IndexError:
+                    # current cell doesn't have a value
+                    cell_val = ''
+
                 try:
                     cell_formula = str(re_cell_formula.findall(first_match)[0])
                 except IndexError:
                     # current tag does not have a formula
                     cell_formula = ''
+
+
+                # cell_val = str(re_cell_val.findall(first_match)[0])
+                # try:
+                #     frmla = re_cell_formula.findall(first_match)
+                #     cell_formula = str(get_item_from_list(frmla, 0))
+                #     # cell_formula = str(re_cell_formula.findall(first_match)[0])
+                # except IndexError:
+                #     # current tag does not have a formula
+                #     cell_formula = ''
 
                 if is_commonString:
                     cell_val = str(sharedString[int(cell_val)])


### PR DESCRIPTION
The issue:
While using the library, I was getting an IndexError. The re_cell_val.findall(first_match) was returning a empty list for a cell which had a formula returning an empty value.

My fix:
Just like for an empty cell formula, added try/except to set it to an empty string.

It looks like it fixed the problem without breaking anything.