### PR TITLE
Bug Fixes

### DIFF
--- a/pylightxl/database.py
+++ b/pylightxl/database.py
@@ -166,9 +166,14 @@ class Worksheet():
 
     def update_index(self, row, col, val):
         address = index2address(row, col)
+        self.maxcol = col if col > self.maxcol else self.maxcol
+        self.maxrow = row if row > self.maxrow else self.maxrow
         self._data.update({address: {'v':val,'f':'','s':''}})
 
     def update_address(self, address, val):
+        row, col = address2index(address)
+        self.maxcol = col if col > self.maxcol else self.maxcol
+        self.maxrow = row if row > self.maxrow else self.maxrow
         self._data.update({address: {'v':val,'f':'','s':''}})
 
     def row(self, row):

--- a/pylightxl/readxl.py
+++ b/pylightxl/readxl.py
@@ -99,8 +99,8 @@ def get_sheetnames(file):
 
     text = file.read().decode()
 
-    tag_sheets = re.compile(r'(?<=<sheets>)(.*)(?=</sheets>)')
-    sheet_section = tag_sheets.findall(text)[0]
+    tag_sheets = re.compile(r'(?<=<sheets>)([\s\S]*)(?=</sheets>)')
+    sheet_section = tag_sheets.findall(text)[0].strip()
     # this will find something like:
     # ['sheet name="Sheet1" sheetId="1" r:id="rId1"/><sheet name="sh2" sheetId="2" r:id']
 

--- a/pylightxl/writexl.py
+++ b/pylightxl/writexl.py
@@ -261,7 +261,8 @@ def new_writer(db, path):
 
     filename = path.split('/')[-1]
     filename = filename if filename.split('.')[-1] == 'xlsx' else '.'.join(filename.split('.')[:-1] + ['xlsx'])
-    path = '/'.join(path.split('/')[:-1]) + filename
+    path = '/'.join(path.split('/')[:-1])
+    path = path + '/' + filename if path else filename
 
     with zipfile.ZipFile(path, 'w') as zf:
         text_rels = new_rels_text(db)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,0 +1,47 @@
+# standard lib imports
+from unittest import TestCase
+from os import remove
+
+# python27 handling
+try:
+    ModuleNotFoundError
+except NameError:
+    ModuleNotFoundError = ImportError
+
+# local lib imports
+try:
+    from pylightxl.readxl import readxl
+    from pylightxl.writexl import writexl
+    from pylightxl.database import Database, Worksheet
+except ModuleNotFoundError:
+    import sys
+    import os
+
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname('test_read_write'), '..')))
+
+    from pylightxl.readxl import readxl
+    from pylightxl.writexl import writexl
+    from pylightxl.database import Database, Worksheet
+
+
+class TestIntegration(TestCase):
+
+    def test_reading_written_ws(self):
+        file_path = 'temporary_test_file.xlsx'
+        db = Database()
+        db.add_ws('new_ws', {})
+        writexl(db, file_path)
+        db = readxl(file_path)
+        self.assertEqual(db.ws_names, ['new_ws'])
+        remove(file_path)
+
+    def test_reading_written_cells(self):
+        file_path = 'temporary_test_file.xlsx'
+        db = Database()
+        db.add_ws('new_ws', {})
+        ws = db.ws('new_ws')
+        ws.update_index(row=4, col=2, val=42)
+        writexl(db, file_path)
+        db = readxl(file_path)
+        self.assertEqual(db.ws('new_ws').index(4, 2), 42)
+        remove(file_path)

--- a/test/test_worksheet.py
+++ b/test/test_worksheet.py
@@ -1,0 +1,31 @@
+# standard lib imports
+from unittest import TestCase
+
+# python27 handling
+try:
+    ModuleNotFoundError
+except NameError:
+    ModuleNotFoundError = ImportError
+
+# local lib imports
+try:
+    from pylightxl.database import Database, Worksheet
+except ModuleNotFoundError:
+    import sys
+    import os
+
+    sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname('test_read_write'), '..')))
+
+    from pylightxl.database import Database, Worksheet
+
+
+class TestWorksheet(TestCase):
+
+    def test_update_index(self):
+        ws = Worksheet({})
+        ws.update_index(row=4, col=2, val=42)
+        self.assertEqual(ws.size, [4, 2])
+        self.assertEqual(ws.index(4, 2), 42)
+        self.assertEqual(ws.address('B4'), 42)
+        self.assertEqual(ws.row(4)[1], 42)
+        self.assertEqual(ws.col(2)[3], 42)


### PR DESCRIPTION
Fixed a bug preventing worksheets written with writexl from being read with readxl. The regex used did not work if there were linefeeds between the <worksheets> tags (writexl added the linefeeds, excel does not add linefeeds).

Fixed a bug preventing inserting new cells outside of a worksheet's used range from updating the size and being written to a file. The maxrow and maxcol were not being updated when data was added to new cells. Only cells within the worksheet's size were being saved.

Fixed a bug which caused new files to be saved with an incorrect filepath. If writexl was called with the following new filepath - 'a/b/c.xlsx', the new workbook would be saved to 'a/bc.xlsx'. 

Added new tests.