### PR TITLE
Fix a bad link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Project featured on [PythonBytes Podcast Episode #165](https://pythonbytes.fm/ep
 ---
 
 #### **Setup**
-pylightxl is officially published on [pypi.org](pypi.org), however one of the
+pylightxl is officially published on [pypi.org](https://pypi.org), however one of the
 key features of pylightxl is that it is packed light in case the user has pip
 and/or download restrictions, see [docs - installation](https://pylightxl.readthedocs.io/en/latest/installation.html)
 


### PR DESCRIPTION
Hi, thanks for this project.

There is an invalid (relative) link to pypi.org in README, pointing to a non-existent page `https://github.com/PydPiper/pylightxl/blob/master/pypi.org`.

I just added `https://` to it.
