### PR TITLE
chore: update version

### DIFF
--- a/pylightxl/pylightxl.py
+++ b/pylightxl/pylightxl.py
@@ -4,7 +4,7 @@
 """
 Title: pylightxl
 Developed by: pydpiper
-Version: 1.57
+Version: 1.58
 License: MIT
 
 Copyright (c) 2019 Viktor Kis


### PR DESCRIPTION
Noticed the version was still set to 1.57 after updating to 1.58.  I _think_ this needs to be bumped? 