### PR TITLE
Fix typos in warning message

### DIFF
--- a/pylightxl/pylightxl.py
+++ b/pylightxl/pylightxl.py
@@ -188,7 +188,7 @@ def readxl_check_excelfile(fn):
         raise UserWarning('pylightxl - Incorrect file entry ({}).'.format(fn))
 
     if not os.path.isfile(fn):
-        raise UserWarning('pylightxl - File ({}) does not exit.'.format(fn))
+        raise UserWarning('pylightxl - File ({}) does not exist.'.format(fn))
 
     extension = fn.split('.')[-1]
 

--- a/test/test_readxl.py
+++ b/test/test_readxl.py
@@ -33,7 +33,7 @@ class TestReadxl_BadInput(TestCase):
     def test_bad_fn_exist(self):
         with self.assertRaises(UserWarning) as e:
             _ = xl.readxl('bad')
-            self.assertEqual('pylightxl - File ({}) does not exit.'.format('bad'), e)
+            self.assertEqual('pylightxl - File ({}) does not exist.'.format('bad'), e)
 
     def test_bad_fn_ext(self):
         with self.assertRaises(UserWarning) as e:


### PR DESCRIPTION
There was a previous issue about this but looks like the changes didn't end up making it into master

> It is fixed on the current github master, this will be rolled into the next release

_Originally posted by @PydPiper in https://github.com/PydPiper/pylightxl/issues/33#issuecomment-797228662_