### PR TITLE
Warn and skip invalid defined-name instead of raising

### DIFF
--- a/pylightxl/pylightxl.py
+++ b/pylightxl/pylightxl.py
@@ -65,6 +65,7 @@ import re
 import os
 import sys
 import shutil
+import warnings
 from xml.etree import cElementTree as ET
 import time
 from datetime import datetime, timedelta
@@ -242,9 +243,11 @@ def readxl_get_workbook(fn):
         try:
             ws, address = fulladdress.split('!')
         except ValueError:
-            raise UserWarning('pylightxl - Ill formatted workbook.xml. '
-                              'NamedRange does not contain sheet reference (ex: "Sheet1!A1"): '
-                              '{name} - {fulladdress}'.format(name=name, fulladdress=fulladdress))
+            msg = ('pylightxl - Ill formatted workbook.xml. '
+                   'Skpping NamedRange not containing sheet reference (ex: "Sheet1!A1"): '
+                   '{name} - {fulladdress}'.format(name=name, fulladdress=fulladdress))
+            warnings.warn(msg, UserWarning)
+            continue
 
         rv['nr'][name] = {'nr': name, 'ws': ws, 'address': address}
 

--- a/test/test_readxl.py
+++ b/test/test_readxl.py
@@ -53,11 +53,11 @@ class TestReadxl_BadInput(TestCase):
                               'File extension supported: .xlsx .xlsm'.format('csv'), e)
 
     def test_bad_readxl_workbook_format(self):
-        with self.assertRaises(UserWarning) as e:
+        msg = ('pylightxl - Ill formatted workbook.xml. '
+               'Skipping NamedRange not containing sheet reference (ex: "Sheet1!A1"): '
+               '{name} - {fulladdress}'.format(name='single_nr', fulladdress='$E$6'))
+        with self.assertWarns(UserWarning, msg=msg):
             _ = xl.readxl_get_workbook('./bad_nr_workbook.zip')
-            self.assertRaises('pylightxl - Ill formatted workbook.xml. '
-                              'NamedRange does not contain sheet reference (ex: "Sheet1!A1"): '
-                              '{name} - {fulladdress}'.format(name='single_nr', fulladdress='$E$6'), e)
 
 
 class TestReadCSV(TestCase):


### PR DESCRIPTION
An invalid defined name does not seem to me an unexpected error that would stop the processing of the data.

For example, I'm processing a lot of xslx created with R (not by me), that have dummy ranges. For example:

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
    <fileVersion appName="xl" lastEdited="5" lowestEdited="5" rupBuild="9303"/>
    <workbookPr/>
    <bookViews>
        <workbookView windowHeight="6105" windowWidth="13125" xWindow="0" yWindow="0"/>
    </bookViews>
    <sheets>
        <sheet name="com2021" r:id="rId1" sheetId="1"/>
    </sheets>
    <definedNames>
        <definedName hidden="1" name="_AMO_UniqueIdentifier">&quot;'f570e99d-b15a-4b20-a455-86810c1c14ea'&quot;</definedName>
    </definedNames>
    <calcPr calcId="0"/>
</workbook>
```

Here is then a proposal to switch from an Exception to a proper Warning.

Thanks for reviewing :)